### PR TITLE
docs: add multi-language README prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,14 @@
 - `// Write API docs for this endpoint`
   <sub>REST or GraphQL backends.</sub>
 
-- `// Generate Sphinx-style docstrings for this Python module/class/function...`
+- `// Generate Sphinx-style docstrings for this Python module/class/function…`
   <sub>Ideal for Python projects using Sphinx for documentation generation.</sub>
+
+- `// Translate README.md into Spanish, French, and Simplified Chinese; save as README.es.md, README.fr.md, README.zh-CN.md`
+  <sub>One-shot localization for the three most requested languages.</sub>
+
+- `// Translate README.md into {language}; save as README.{lang}.md`
+  <sub>Ad-hoc localization—replace {language}/{lang} with any target language code.</sub>
 
 
 


### PR DESCRIPTION
### Description
Added two prompts that let Jules translate `README.md` into multiple languages and save the localized files.

### Checklist
- [x] I've added the prompt in the correct section.
- [x] The prompt is helpful, concise, and clear.
- [x] I've double-checked the markdown formatting.

