### PR TITLE
Fixed broken PR contribute link

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,4 +216,4 @@
 Your contributions are welcome! Add new prompts, fix formatting, or suggest categories.
 
 - 📄 [Contributing Guide](contributing.md)
-- 🪄 Open a [Pull Request](https://github.com/YOUR_REPO/pulls)
+- 🪄 Open a [Pull Request](../../pulls)


### PR DESCRIPTION
### Description
The README’s pull request link pointed to a placeholder URL. This broke navigation for contributors wanting to open a PR.

### Checklist
- [*] I've replaced the invalid placeholder link with a relative link pointing to the repository’s PR page
-  I've added the prompt in the correct section.
-  The prompt is helpful, concise, and clear.
-  I've double-checked the markdown formatting.