### PR TITLE
feat: Integrate Semgrep for SAST

### DIFF
--- a/.github/workflows/sast-scan.yml
+++ b/.github/workflows/sast-scan.yml
@@ -1,0 +1,25 @@
+# .github/workflows/sast-scan.yml
+name: SAST Scan
+
+on:
+  push:
+    branches: [ main ] # Adjust branches as needed, e.g., [ '*' ] for all branches
+  pull_request:
+    branches: [ main ] # Adjust branches as needed
+  workflow_dispatch: # Allows manual triggering
+
+jobs:
+  sast-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x' # Use a recent Python version
+
+      # The run-sast-scan.sh script handles Semgrep installation and execution
+      - name: Run SAST Scan Script
+        run: ./run-sast-scan.sh

--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
+## Static Application Security Testing (SAST)
+
+This project integrates **Semgrep**, an open-source static analysis tool, to proactively identify potential security vulnerabilities and code quality issues.
+
+### Automated Scanning via GitHub Actions
+
+A GitHub Actions workflow is configured in `.github/workflows/sast-scan.yml` to automatically scan the codebase on every `push` and `pull_request` to the `main` branch. This helps in early detection of issues.
+
+The workflow uses the `run-sast-scan.sh` script, which in turn utilizes the Semgrep configuration defined in `semgrep.yml`.
+
+### Local Usage
+
+To run Semgrep locally:
+
+1.  **Install Python and Pip**: Ensure you have Python 3.6+ and pip installed.
+2.  **Install Semgrep**:
+    ```bash
+    python3 -m pip install semgrep
+    ```
+3.  **Run the Scan Script**:
+    Execute the scan script from the root of the repository:
+    ```bash
+    ./run-sast-scan.sh
+    ```
+    This will use the rules defined in `semgrep.yml`.
+
+### Configuration
+
+*   **Rulesets**: The primary Semgrep configuration is in `semgrep.yml`. By default, it uses the `p/default` ruleset, which is a collection of general-purpose rules for security, correctness, and performance. You can customize this file to add more specific rulesets (e.g., `r/python`, `r/java`, `r/owasp-top-ten`) or individual rules. Refer to the [Semgrep Registry](https://semgrep.dev/explore) for available rules.
+*   **Ignoring Files/Directories**: To exclude specific files or directories from scanning (e.g., test files, vendor directories), add their paths to the `.semgrepignore` file, one per line.
+
+---
 <p align="center">
   <img src="assets/jules-readme.png" alt="Jules Awesome List" width="600">
 </p>

--- a/run-sast-scan.sh
+++ b/run-sast-scan.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# This script runs Semgrep for static analysis.
+# It's intended to be used in CI/CD pipelines.
+
+echo "Starting Semgrep SAST scan..."
+
+# Install Semgrep if not available (common in CI environments)
+# This is just an example; actual installation might vary based on CI runner setup.
+if ! command -v semgrep &> /dev/null
+then
+    echo "Semgrep not found. Attempting to install via pip..."
+    python3 -m pip install semgrep
+    # Ensure the semgrep binary is in the PATH if installed this way
+    # This might require export PATH="$HOME/.local/bin:$PATH" depending on the system
+fi
+
+# Run Semgrep CI. It will use configurations from .semgrep.yml or other discovered rule files.
+# The `semgrep ci` command is suitable for CI environments and will exit with a non-zero code
+# if issues are found, which can fail the build.
+semgrep ci
+
+echo "Semgrep scan complete."

--- a/semgrep.yml
+++ b/semgrep.yml
@@ -1,0 +1,12 @@
+# semgrep.yml
+#
+# See Semgrep docs for more on configuration:
+# https://semgrep.dev/docs/writing-rules/rule-syntax/
+#
+# For a list of available rulesets:
+# https://semgrep.dev/explore
+rules:
+  # The "p/default" ruleset is a curated collection of rules from various sources
+  # that are generally applicable and have a low false-positive rate.
+  # It includes rules for security, correctness, and performance.
+  - p/default


### PR DESCRIPTION
Adds an initial setup for Static Application Security Testing (SAST) using Semgrep.

This includes:
- A `semgrep.yml` configuration file with the `p/default` ruleset.
- An empty `.semgrepignore` for future exclusions.
- A `run-sast-scan.sh` script to execute Semgrep, suitable for CI environments.
- A `.github/workflows/sast-scan.yml` GitHub Actions workflow to automate scanning on push/pull_request to main.
- Updated `README.md` with details on the SAST setup, local usage, and CI integration.

This provides a foundational layer for proactive security scanning in the CI/CD pipeline.

### Description

Please provide a brief description of your addition or change.

### Checklist

- [ ] I've added the prompt in the correct section.
- [ ] The prompt is helpful, concise, and clear.
- [ ] I've double-checked the markdown formatting.
