### PR TITLE
Fix broken pull request link in Contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,4 +216,4 @@
 Your contributions are welcome! Add new prompts, fix formatting, or suggest categories.
 
 - 📄 [Contributing Guide](contributing.md)
-- 🪄 Open a [Pull Request](https://github.com/YOUR_REPO/pulls)
+- 🪄 Open a [Pull Request](https://github.com/google-labs-code/jules-awesome-list/pulls)


### PR DESCRIPTION
The pull request link in the Contributing section used a placeholder URL (YOUR_REPO) instead of the actual repository URL, resulting in a broken 404 link. Changed to point to the correct repository.